### PR TITLE
Fix string length in 64-bit mode

### DIFF
--- a/s390x.s
+++ b/s390x.s
@@ -9,7 +9,7 @@ base:
 	sr	%r1, %r2
 	lhi	%r2, 1
 	la	%r3, msg(%r1)
-	lhi	%r4, 3
+	lghi	%r4, 3
 	svc	4
 
 	xr	%r2, %r2


### PR DESCRIPTION
"Load Halfword Immediate" leaves higher register bits untouched,
that made string length for "write" call longer than buffer
and produced extra output beyond "ok" on s390x architecture.

This patch fixes the issue by loading an immediate into all 64 bits.