### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+arch-test (0.18-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 25 Mar 2022 09:26:28 -0000
+
 arch-test (0.18-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/kilobyte/arch-test/issues
+Bug-Submit: https://github.com/kilobyte/arch-test/issues/new
+Repository: https://github.com/kilobyte/arch-test.git
+Repository-Browse: https://github.com/kilobyte/arch-test


### PR DESCRIPTION

Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/arch-test/93914eaa-7284-4e6b-bb29-df6ab7fcdd52.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/93914eaa-7284-4e6b-bb29-df6ab7fcdd52/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/93914eaa-7284-4e6b-bb29-df6ab7fcdd52/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/93914eaa-7284-4e6b-bb29-df6ab7fcdd52/diffoscope)).
