### PR TITLE
Revert "Search loong64 compiler with fabi suffix"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ MIPS=mips-linux-gnu
 POWERPC=powerpc-linux-gnu
 ARM=arm-linux-gnueabihf
 SPARC=sparc64-linux-gnu
-LOONG64=loongarch64-linux-gnuf64
 -include config
 all: $(ARCHS:%=arch-test-%)
 
@@ -181,8 +180,8 @@ arch-test-riscv64: riscv64.s
 	riscv64-linux-gnu-ld -z noexecstack -s riscv64.o -o $@
 
 arch-test-loong64: loong64.s
-	$(LOONG64)-as $^ -o loong64.o
-	$(LOONG64)-ld -z noexecstack -s loong64.o -o $@
+	loongarch64-linux-gnu-as $^ -o loong64.o
+	loongarch64-linux-gnu-ld -z noexecstack -s loong64.o -o $@
 
 arch-test-arc: arc.s
 	arc-linux-gnu-as $^ -o arc.o

--- a/configure
+++ b/configure
@@ -37,7 +37,6 @@ alt qw(MIPS mips-linux-gnu mipsel-linux-gnu mips64-linux-gnuabi64
 alt qw(POWERPC powerpc-linux-gnu powerpc64-linux-gnu);
 alt qw(ARM arm-linux-gnueabihf arm-linux-gnueabi);
 alt qw(SPARC sparc64-linux-gnu sparc-linux-gnu);
-alt qw(LOONG64 loongarch64-linux-gnuf64 loongarch64-linux-gnu);
 
 while (/^arch-test-([a-z0-9-]+):.*\n\t([a-z0-9_.-]+-(?:gcc|as))/mg)
 {


### PR DESCRIPTION
This reverts commit 8122409b4069ebfdd07e0231ad049338ee18b1c0.

LoongArch just removed the usage of `f64` fabi_suffix. See: https://loongson.github.io/LoongArch-Documentation/LoongArch-toolchain-conventions-EN.html#_gnu_target_triplets_and_multiarch_specifiers