### PR TITLE
ppc64el: Produce an ELFv2 binary

### DIFF
--- a/ppc64el.s
+++ b/ppc64el.s
@@ -2,14 +2,11 @@
 msg:	.ascii "ok\n"
 .text
 .globl _start
-.section        ".opd","aw"
 .align 3
 _start:
-.quad   ._start,.TOC.@tocbase,0
-.previous
-
-.global  ._start
-._start:
+	addis	2, 12, .TOC. - _start@ha
+	addi	2, 2,  .TOC. - _start@l
+.localentry _start, . -_start
 	mtvsrd	0, 0	# trigger SIGILL on power7 CPUs
 
 	li	0, 4	# syscall write(r3, r4, r5)


### PR DESCRIPTION
The ppc64el.s test was presumably copied from the ppc64.s test, and although it correctly produces a little endian binary, that binary uses the ELF v1 ABI.

  $ file arch-test-ppc64el
  arch-test-ppc64el: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500
  Power ELF V1 ABI, version 1 (SYSV), statically linked, stripped

Note "Power ELF V1 ABI".

Although the combination of little endian and ELF V1 ABI is supported by the toolchain and the kernel, it's not widely used or well tested. Traditional ppc64 systems use big endian ELF V1 ABI, and ppc64le systems use little endian ELF V2 ABI.

So to be more standard, rework ppc64el.s to produce an ELF V2 binary. The key changes are to not create an opd, and include a proper ELF V2 entry point using .localentry.

The result:

  $ file arch-test-ppc64el
  arch-test-ppc64el: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500,
  OpenPOWER ELF V2 ABI, version 1 (SYSV), statically linked, stripped

Note "OpenPOWER ELF V2 ABI".

Testing on a ppc64le system:
  $ ./run-all
  ppc64el
  ret=0 stdout=ok